### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.7.0
-- Fixed: Public Lock stats chart sizing for Cards Remaining by Type
+- Fixed: Public Lock stats chart sizing for Cards Remaining by Type\
+- Fixed: Lockee longest lock completed sparkline will now exclude abandoned locks
 - Updated: Web app's title from chastikey-web to Kiera + ChastiKey
 - Updated: Lockee Lock discard pile removing text about not including greens as they now show up in the data
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.7.0
+- Updated: Web app's title from chastikey-web to Kiera + ChastiKey
+
 0.6.0
 - Fixed: After deleting an outcome the buttons will come back and be enabled momentarily
 - Fixed: [ #1 ] by @magrauer - Fix gray color of Decisions tile when not authenticated. Currently it is always showing dark blue.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 0.7.0
 - Fixed: Public Lock stats chart sizing for Cards Remaining by Type
 - Updated: Web app's title from chastikey-web to Kiera + ChastiKey
+- Updated: Lockee Lock discard pile removing text about not including greens as they now show up in the data
 
 0.6.0
 - Fixed: After deleting an outcome the buttons will come back and be enabled momentarily

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.7.0
+- Fixed: Public Lock stats chart sizing for Cards Remaining by Type
 - Updated: Web app's title from chastikey-web to Kiera + ChastiKey
 
 0.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chastikey-web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Emma <RileyIO>",
   "private": true,
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -4,13 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>chastikey-web</title>
+    <title>Kiera + ChastiKey</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but chastikey-web doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but Kiera + ChastiKey doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/src/components/LockeeViewPastLock.vue
+++ b/src/components/LockeeViewPastLock.vue
@@ -67,7 +67,7 @@
             <template v-slot:activator="{ on }">
               <v-icon style="display: inline-block;" v-on="on" small>mdi-information-outline</v-icon>
             </template>
-            <span>The last ({{ lock.discardPile.length }}) cards discarded (not greens):</span>
+            <span>The last ({{ lock.discardPile.length }}) cards discarded:</span>
           </v-tooltip>
         </span>
 

--- a/src/components/LockeeViewRunningLock.vue
+++ b/src/components/LockeeViewRunningLock.vue
@@ -67,7 +67,7 @@
             <template v-slot:activator="{ on }">
               <v-icon style="display: inline-block;" v-on="on" small>mdi-information-outline</v-icon>
             </template>
-            <span>The last ({{ lock.discardPile.length }}) cards discarded (not greens):</span>
+            <span>The last ({{ lock.discardPile.length }}) cards discarded:</span>
           </v-tooltip>
         </span>
 

--- a/src/views/Lockee.vue
+++ b/src/views/Lockee.vue
@@ -292,7 +292,10 @@ export default class LockeeView extends Vue {
       return b.timestampLocked - a.timestampLocked
     })
     // Generate sparkline data specific array and ordered ASC
-    this.data.sparklineData = this.data.pastLocks.map(l => l.totalTimeLocked).reverse()
+    this.data.sparklineData = this.data.pastLocks
+      .filter(l => !(l.lockDeleted === 1 && l.status === 'Locked'))
+      .map(l => l.totalTimeLocked)
+      .reverse()
     this.data.sparklineAutoDraw = true
     this.isLoadingCK = false
   }

--- a/src/views/StatsLocks.vue
+++ b/src/views/StatsLocks.vue
@@ -67,7 +67,7 @@
               />
             </v-card>
           </v-col>
-          <v-col cols="4">
+          <v-col cols="12" sm="12" md="4" lg="4">
             <v-card>
               <apexchart
                 type="donut"


### PR DESCRIPTION
**Items in this version:**

- Fixed: Public Lock stats chart sizing for Cards Remaining by Type\
- Fixed: Lockee longest lock completed sparkline will now exclude abandoned locks
- Updated: Web app's title from chastikey-web to Kiera + ChastiKey
- Updated: Lockee Lock discard pile removing text about not including greens as they now show up in the data